### PR TITLE
Fix ZenSeq openArray bug preventing array types from creating ZenValue

### DIFF
--- a/model_citizen.nimble
+++ b/model_citizen.nimble
@@ -1,4 +1,4 @@
-version = "0.19.4"
+version = "0.19.5"
 author = "Scott Wadden"
 description = "Nothing for now"
 license = "MIT"

--- a/src/model_citizen/zens/initializers.nim
+++ b/src/model_citizen/zens/initializers.nim
@@ -239,7 +239,7 @@ proc init*(
 
 proc init*(
     _: type Zen,
-    T: type[ref | object | SomeOrdinal | SomeNumber],
+    T: type[ref | object | array | SomeOrdinal | SomeNumber],
     flags = default_flags,
     ctx = ctx(),
     id = "",
@@ -248,7 +248,7 @@ proc init*(
   ctx.setup_op_ctx
   result = Zen[T, T](flags: flags).defaults(ctx, id, op_ctx)
 
-proc init*[T: ref | object | tuple | SomeOrdinal | SomeNumber | string | ptr](
+proc init*[T: ref | object | tuple | array | SomeOrdinal | SomeNumber | string | ptr](
     _: type Zen,
     tracked: T,
     flags = default_flags,
@@ -295,7 +295,7 @@ proc init*[K, V](
 
 proc init*[O](
     _: type Zen,
-    tracked: open_array[O],
+    tracked: seq[O],
     flags = default_flags,
     ctx = ctx(),
     id = "",
@@ -305,7 +305,7 @@ proc init*[O](
   var self = Zen[seq[O], O](flags: flags).defaults(ctx, id, op_ctx)
 
   mutate(op_ctx):
-    self.tracked = tracked.to_seq
+    self.tracked = tracked
   result = self
 
 proc init*[O](
@@ -353,7 +353,7 @@ proc init*(
   result = ZenTable[K, V](flags: flags).defaults(ctx, id, op_ctx)
 
 proc zen_init_private*[K, V](
-    tracked: open_array[(K, V)],
+    tracked: seq[(K, V)],
     flags = default_flags,
     ctx = ctx(),
     id = "",

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -10,6 +10,8 @@ import model_citizen/[types {.all.}, zens {.all.}, zens/contexts {.all.}]
 
 import model_citizen/components/type_registry
 
+type Vector3 = array[3, float]
+
 proc run*() =
   var change_count = 0
   proc count_changes(obj: auto): ZID {.discardable.} =
@@ -861,6 +863,30 @@ proc run*() =
       ctx1.boop
       check src_change_id == 4
       check dest_change_id == 4
+
+  test "Vector3 array type should create ZenValue not ZenSeq":
+    var vec = Vector3([1.0, 2.0, 3.0])
+    var zen_vec = ~vec
+    
+    # Verify this is a ZenValue[Vector3], not a ZenSeq[float]
+    check zen_vec is ZenValue[Vector3]
+    check zen_vec.value == vec
+    
+    # Test that it can sync properly
+    var ctx1 = init_test_ctx("ctx1") 
+    var ctx2 = init_test_ctx("ctx2")
+    ctx2.subscribe(ctx1)
+    
+    var v1 = Zen.init(vec, ctx = ctx1, id = "vector")
+    ctx1.boop
+    
+    var v2 = ZenValue[Vector3](ctx2["vector"])
+    check v1.value == v2.value
+    
+    # Test mutation
+    v1.value = Vector3([4.0, 5.0, 6.0])
+    ctx1.boop
+    check v2.value == Vector3([4.0, 5.0, 6.0])
 
 when is_main_module:
   Zen.bootstrap


### PR DESCRIPTION
## Summary
- Fixes issue where `array[3, float]` types (like Vector3) were incorrectly creating `ZenSeq[float]` instead of `ZenValue[Vector3]`
- Changes ZenSeq init procedures to only accept seq types instead of openArray
- Adds array type support to ZenValue init procedures
- Adds comprehensive test with Vector3 type to verify the fix

## Changes Made
- **Core Fix**: Modified `initializers.nim` to restrict ZenSeq init procedures to `seq[O]` instead of `open_array[O]`
- **Array Support**: Added `array` to the type constraints for ZenValue init procedures  
- **Version Bump**: Incremented version to 0.19.5
- **Test Coverage**: Added Vector3 test to ensure array types create ZenValue and sync properly

## Test Plan
- [x] Added Vector3 test that verifies `array[3, float]` creates `ZenValue[Vector3]` 
- [x] Test confirms Vector3 values sync correctly across contexts
- [x] Test validates mutations work properly

🤖 Generated with [Claude Code](https://claude.ai/code)